### PR TITLE
Block fork pull request workflow jobs

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   review:
+    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - uses: fluxninja/openai-pr-reviewer@main


### PR DESCRIPTION
## Summary
- Skip GitHub Actions jobs for pull requests opened from forks.
- Keep push, merge queue, issue, and same-repository pull request behavior unchanged.

## Why
Public fork pull requests can run attacker-controlled workflow code. Skipping those jobs prevents those pull requests from reaching repository secrets through GitHub Actions.

## Validation
- Parsed the changed workflow files with `yq e '.'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve review job handling for internal automation processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/dotfiles/pull/4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->